### PR TITLE
Add auto-publishing ability

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,10 @@ To start using Laravel, add the Service Provider and the Facade to your `config/
 ]
 ```
 
+Now, you should publish package's config file to your config directory by using following command:
+
+```sh php artisan vendor:publish```
+
 ## Basic Usage
 
 To use Laravel PDF add something like this to one of your controllers. You can pass data to a view in `/resources/views`.

--- a/src/LaravelPdf/PdfServiceProvider.php
+++ b/src/LaravelPdf/PdfServiceProvider.php
@@ -14,6 +14,19 @@ class PdfServiceProvider extends BaseServiceProvider {
 	 */
 	protected $defer = false;
 
+
+	/*
+	* Bootstrap the application service
+	*
+	* @return void
+	*/
+	public function boot()
+	{
+		$this->publishes([
+            	__DIR__ . '/../config/pdf.php' => config_path('pdf.php'),
+        	]);
+    	}
+	
 	/**
 	 * Register the service provider.
 	 *


### PR DESCRIPTION
https://github.com/niklasravnsborg/laravel-pdf/issues/56
Now, users can publish `pdf.php` config file by running `php artisan vendor:publish` command.