### PR TITLE
Watermark has to be set BEFORE WriteHTML

### DIFF
--- a/src/LaravelPdf/Pdf.php
+++ b/src/LaravelPdf/Pdf.php
@@ -46,6 +46,13 @@ class Pdf {
 		$this->mpdf->SetKeywords      ( $this->getConfig('keywords') );
 		$this->mpdf->SetDisplayMode   ( $this->getConfig('display_mode') );
 
+		if (Config::has('pdf.watermark_image')) {
+			call_user_func_array(array($this, 'setWatermarkImage'), $this->getConfig('watermark_image'));
+		}
+		if (Config::has('pdf.watermark_text')) {
+			call_user_func_array(array($this, 'setWatermarkText'), $this->getConfig('watermark_text'));
+		}
+
 		$this->mpdf->WriteHTML($html);
 	}
 
@@ -133,5 +140,19 @@ class Pdf {
 	public function stream($filename = 'document.pdf')
 	{
 		return $this->mpdf->Output($filename, 'I');
+	}
+
+	private function setWatermarkImage($src, $alpha = 0.2, $size = 'D', $position = 'P')
+	{
+		$this->mpdf->showWatermarkImage = true;
+		return $this->mpdf->SetWatermarkImage($src);
+		return $this->mpdf->SetWatermarkImage($src, $alpha, $size, $position);
+	}
+
+	private function setWatermarkText($text, $alpha = 0.2)
+	{
+		$this->mpdf->showWatermarkText = true;
+		return $this->mpdf->SetWatermarkText($text);
+		return $this->mpdf->SetWatermarkText($text, $alpha);
 	}
 }

--- a/src/config/pdf.php
+++ b/src/config/pdf.php
@@ -8,5 +8,6 @@ return [
 	'keywords'              => '',
 	'creator'               => 'Laravel Pdf',
 	'display_mode'          => 'fullpage',
-	'tempDir'               => base_path('../temp/')
+	'tempDir'               => base_path('../temp/'),
+	'watermark_text'        => ['DRAFT', 0.3],
 ];


### PR DESCRIPTION
In order to properly use watermark, it has to be set before calling WritePDF (see [issue 903](https://github.com/mpdf/mpdf/issues/903) on mpdf github)

Using configuration you can now set image or text watermark on ALL pages.

It could either be from config file or from PDF::loadView '$config' argument.

I did retrieved a delete part of your code from [commit 3bd2bc62c6138a609f6ebe06fa93a6e28419e9bd](https://github.com/niklasravnsborg/laravel-pdf/commit/3bd2bc62c6138a609f6ebe06fa93a6e28419e9bd)


Fix issues #45 and #61