### PR TITLE
Add missing property to PDF with typehint

### DIFF
--- a/src/LaravelPdf/Pdf.php
+++ b/src/LaravelPdf/Pdf.php
@@ -15,6 +15,11 @@ class Pdf {
 
 	protected $config = [];
 
+	/**
+	 * @var Mpdf\Mpdf
+	 */
+	public $mpdf;
+
 	public function __construct($html = '', $config = [])
 	{
 		$this->config = $config;


### PR DESCRIPTION
The `$mpfd` property is publicly available, but was not formally a property of the class and was lacking a typehint. This results in errors when using a static code analyser such as phpstan (larastan).