### PR TITLE
Specify the provider to be published

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To start using Laravel, add the Service Provider and the Facade to your `config/
 Now, you should publish package's config file to your config directory by using following command:
 
 ```
-php artisan vendor:publish
+php artisan vendor:publish --provider="niklasravnsborg\LaravelPdf\PdfServiceProvider"
 ```
 
 ## Basic Usage


### PR DESCRIPTION
Specify the provider in the `php artisan vendor:publish` instructions.