### PR TITLE
feat: Add the ability to use and customize files in PDFA-1b format.

### DIFF
--- a/src/LaravelPdf/Pdf.php
+++ b/src/LaravelPdf/Pdf.php
@@ -50,6 +50,15 @@ class Pdf {
 		$this->mpdf->SetKeywords      ( $this->getConfig('keywords') );
 		$this->mpdf->SetDisplayMode   ( $this->getConfig('display_mode') );
 
+		if (!empty($this->getConfig('pdf_a'))) {
+			$this->mpdf->PDFA = $this->getConfig('pdf_a');           // Set the flag whether you want to use the pdfA-1b format
+			$this->mpdf->PDFAauto = $this->getConfig('pdf_a_auto');  // Overrides warnings making changes when possible to force PDFA1-b compliance;
+		}
+
+		if (!empty($this->getConfig('icc_profile_path'))) {
+			$this->mpdf->ICCProfile = $this->getConfig('icc_profile_path'); // Specify ICC colour profile
+		}
+
 		if (isset($this->config['instanceConfigurator']) && is_callable(($this->config['instanceConfigurator']))) {
 			$this->config['instanceConfigurator']($this->mpdf);
 		}

--- a/src/config/pdf.php
+++ b/src/config/pdf.php
@@ -8,5 +8,8 @@ return [
 	'keywords'              => '',
 	'creator'               => 'Laravel Pdf',
 	'display_mode'          => 'fullpage',
-	'tempDir'               => base_path('../temp/')
+	'tempDir'               => base_path('../temp/'),
+	'pdf_a'                 => false,
+	'pdf_a_auto'            => false,
+	'icc_profile_path'      => ''
 ];


### PR DESCRIPTION
Hello colleagues!

We are using the niklasravnsborg/laravel-pdf library and it is a very useful library. Thank you for it!

We want to make the library even better and allow the transfer of file settings in the format PDFA-1b.
To do this, I added the processing of three more options.

This will allow you to use the following options, which are already present in the original MDF library, but are not yet in our wrapper for Laravel:
- https://mpdf.github.io/what-else-can-i-do/pdf-a1-b-compliance.html
- https://mpdf.github.io/reference/mpdf-variables/iccprofile.html

Best wishes, Alexey.