### PR TITLE
Update composer.json to fix #225

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "test": "phpunit --colors=always"
     },
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.0|^7.0|^8.0",
         "mpdf/mpdf": "^8.0"
     },
     "autoload": {


### PR DESCRIPTION
This small change fixes #225 by allowing laravel-pdf to be installed on more PHP Versions

An alternative to this is to install with `--ignore-platform-reqs`

For example:
`composer require niklasravnsborg/laravel-pdf --ignore-platform-reqs`

